### PR TITLE
Create Taskflow todo application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# taskflow
-Application taskflow
+# Taskflow
+
+Taskflow est une mini-application web inspirée de Todoist pour organiser vos tâches par projet, gérer leurs priorités et suivre votre progression quotidienne.
+
+## Fonctionnalités principales
+
+- Gestion de projets colorés avec une boîte de réception créée automatiquement
+- Création, édition, suppression et complétion de tâches
+- Filtrage par état (actives ou terminées), date d'échéance et recherche textuelle
+- Résumé en temps réel du nombre total de tâches, terminées et actives
+- Interface responsive avec formulaire rapide pour ajouter de nouvelles tâches
+
+## Démarrage
+
+### Installation des dépendances
+
+```bash
+pip install -r requirements.txt
+```
+
+### Lancer le serveur de développement
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Le serveur expose l'API RESTful sous le préfixe `/api` et sert l'interface web sur [http://localhost:8000](http://localhost:8000).
+
+## Tests
+
+```bash
+pytest
+```
+
+Les tests utilisent une base de données SQLite en mémoire et vérifient les principaux parcours de création et mise à jour des projets et des tâches.

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,24 @@
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+DATABASE_URL = "sqlite:///./taskflow.db"
+engine = create_engine(DATABASE_URL, echo=False, connect_args={"check_same_thread": False})
+
+
+def create_db_and_tables() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+@contextmanager
+def get_session() -> Iterator[Session]:
+    session = Session(engine)
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,179 @@
+from collections import Counter
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from sqlmodel import Session, select
+
+from .database import create_db_and_tables, get_session
+from .models import (
+    Project,
+    ProjectCreate,
+    ProjectRead,
+    ProjectUpdate,
+    Task,
+    TaskCreate,
+    TaskRead,
+    TaskUpdate,
+)
+
+app = FastAPI(title="Taskflow", version="0.1.0")
+static_dir = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    create_db_and_tables()
+    with get_session() as session:
+        inbox_exists = session.exec(select(Project).where(Project.name == "Inbox")).first()
+        if inbox_exists is None:
+            session.add(Project(name="Inbox", color="#2563eb"))
+
+
+@app.get("/", response_class=HTMLResponse)
+def read_index() -> HTMLResponse:
+    index_path = static_dir / "index.html"
+    return HTMLResponse(index_path.read_text(encoding="utf-8"))
+
+
+@app.get("/api/projects", response_model=list[ProjectRead])
+def list_projects(session: Session = Depends(get_session)) -> list[ProjectRead]:
+    projects = session.exec(select(Project).order_by(Project.name)).all()
+    return projects
+
+
+@app.post("/api/projects", response_model=ProjectRead, status_code=201)
+def create_project(project: ProjectCreate, session: Session = Depends(get_session)) -> ProjectRead:
+    existing = session.exec(select(Project).where(Project.name == project.name)).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="A project with this name already exists")
+    db_project = Project.model_validate(project)
+    session.add(db_project)
+    session.flush()
+    session.refresh(db_project)
+    return db_project
+
+
+@app.put("/api/projects/{project_id}", response_model=ProjectRead)
+def update_project(project_id: int, payload: ProjectUpdate, session: Session = Depends(get_session)) -> ProjectRead:
+    db_project = session.get(Project, project_id)
+    if db_project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    update_data = payload.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_project, key, value)
+    session.add(db_project)
+    session.flush()
+    session.refresh(db_project)
+    return db_project
+
+
+@app.delete("/api/projects/{project_id}", status_code=204)
+def delete_project(project_id: int, session: Session = Depends(get_session)) -> None:
+    db_project = session.get(Project, project_id)
+    if db_project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if db_project.name == "Inbox":
+        raise HTTPException(status_code=400, detail="The Inbox project cannot be deleted")
+    for task in db_project.tasks:
+        task.project_id = None
+        session.add(task)
+    session.delete(db_project)
+
+
+@app.get("/api/tasks", response_model=list[TaskRead])
+def list_tasks(
+    project_id: Optional[int] = None,
+    completed: Optional[bool] = None,
+    search: Optional[str] = None,
+    due_before: Optional[date] = None,
+    due_after: Optional[date] = None,
+    session: Session = Depends(get_session),
+) -> list[TaskRead]:
+    statement = select(Task)
+    if project_id is not None:
+        statement = statement.where(Task.project_id == project_id)
+    if completed is not None:
+        statement = statement.where(Task.completed.is_(completed))
+    if search:
+        like_pattern = f"%{search.lower()}%"
+        statement = statement.where(Task.title.ilike(like_pattern) | Task.description.ilike(like_pattern))
+    if due_before is not None:
+        statement = statement.where(Task.due_date <= due_before)
+    if due_after is not None:
+        statement = statement.where(Task.due_date >= due_after)
+    statement = statement.order_by(Task.completed, Task.priority.desc(), Task.due_date.is_(None), Task.due_date)
+    return session.exec(statement).all()
+
+
+@app.get("/api/tasks/{task_id}", response_model=TaskRead)
+def read_task(task_id: int, session: Session = Depends(get_session)) -> TaskRead:
+    task = session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+
+@app.post("/api/tasks", response_model=TaskRead, status_code=201)
+def create_task(payload: TaskCreate, session: Session = Depends(get_session)) -> TaskRead:
+    if payload.project_id is not None and session.get(Project, payload.project_id) is None:
+        raise HTTPException(status_code=400, detail="Project does not exist")
+    task = Task.model_validate(payload)
+    session.add(task)
+    session.flush()
+    session.refresh(task)
+    return task
+
+
+@app.put("/api/tasks/{task_id}", response_model=TaskRead)
+def update_task(task_id: int, payload: TaskUpdate, session: Session = Depends(get_session)) -> TaskRead:
+    task = session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    update_data = payload.model_dump(exclude_unset=True)
+    if "project_id" in update_data and update_data["project_id"] is not None:
+        if session.get(Project, update_data["project_id"]) is None:
+            raise HTTPException(status_code=400, detail="Project does not exist")
+    for key, value in update_data.items():
+        setattr(task, key, value)
+    session.add(task)
+    session.flush()
+    session.refresh(task)
+    return task
+
+
+@app.patch("/api/tasks/{task_id}/toggle", response_model=TaskRead)
+def toggle_task_completion(task_id: int, session: Session = Depends(get_session)) -> TaskRead:
+    task = session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task.completed = not task.completed
+    session.add(task)
+    session.flush()
+    session.refresh(task)
+    return task
+
+
+@app.delete("/api/tasks/{task_id}", status_code=204)
+def delete_task(task_id: int, session: Session = Depends(get_session)) -> None:
+    task = session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    session.delete(task)
+
+
+@app.get("/api/tasks/summary")
+def task_summary(session: Session = Depends(get_session)) -> dict[str, int]:
+    tasks = session.exec(select(Task.completed)).all()
+    counter = Counter(tasks)
+    total = len(tasks)
+    completed = counter.get(True, 0)
+    return {
+        "total": total,
+        "completed": completed,
+        "active": total - completed,
+    }

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,60 @@
+from datetime import date, datetime
+from typing import Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class ProjectBase(SQLModel):
+    name: str = Field(index=True, nullable=False, max_length=80)
+    color: str = Field(default="#7c3aed", max_length=20)
+
+
+class Project(ProjectBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    tasks: list["Task"] = Relationship(back_populates="project")
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class ProjectRead(ProjectBase):
+    id: int
+
+
+class ProjectUpdate(SQLModel):
+    name: Optional[str] = Field(default=None, max_length=80)
+    color: Optional[str] = Field(default=None, max_length=20)
+
+
+class TaskBase(SQLModel):
+    title: str = Field(index=True, nullable=False, max_length=120)
+    description: Optional[str] = Field(default=None)
+    due_date: Optional[date] = Field(default=None, index=True)
+    priority: int = Field(default=2, ge=1, le=4)
+    completed: bool = Field(default=False, index=True)
+    project_id: Optional[int] = Field(default=None, foreign_key="project.id")
+
+
+class Task(TaskBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    project: Optional[Project] = Relationship(back_populates="tasks")
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskRead(TaskBase):
+    id: int
+    created_at: datetime
+
+
+class TaskUpdate(SQLModel):
+    title: Optional[str] = Field(default=None, max_length=120)
+    description: Optional[str] = None
+    due_date: Optional[date] = None
+    priority: Optional[int] = Field(default=None, ge=1, le=4)
+    completed: Optional[bool] = None
+    project_id: Optional[int] = Field(default=None, foreign_key="project.id")

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,294 @@
+const projectList = document.getElementById('projectList');
+const taskList = document.getElementById('taskList');
+const taskForm = document.getElementById('taskForm');
+const taskTitle = document.getElementById('taskTitle');
+const taskDescription = document.getElementById('taskDescription');
+const taskDue = document.getElementById('taskDue');
+const taskPriority = document.getElementById('taskPriority');
+const taskProject = document.getElementById('taskProject');
+const activeProjectTitle = document.getElementById('activeProject');
+const completedFilter = document.getElementById('completedFilter');
+const dueBeforeInput = document.getElementById('dueBefore');
+const searchInput = document.getElementById('searchInput');
+const summaryEl = document.getElementById('summary');
+const addProjectBtn = document.getElementById('addProjectBtn');
+const projectDialog = document.getElementById('projectDialog');
+const projectNameInput = document.getElementById('projectName');
+const projectColorInput = document.getElementById('projectColor');
+const projectDialogSubmit = document.getElementById('projectDialogSubmit');
+
+let projects = [];
+let activeProjectId = null;
+let tasks = [];
+let searchTimeout = null;
+
+async function request(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    const message = detail.detail || 'Une erreur est survenue.';
+    throw new Error(message);
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  return response.json();
+}
+
+async function loadProjects() {
+  projects = await request('/api/projects');
+  renderProjects();
+  populateProjectSelect();
+  if (activeProjectId === null && projects.length > 0) {
+    const inbox = projects.find((project) => project.name === 'Inbox');
+    activeProjectId = inbox ? inbox.id : projects[0].id;
+  }
+  setActiveProjectTitle();
+}
+
+async function loadTasks() {
+  const params = new URLSearchParams();
+  if (activeProjectId) {
+    params.set('project_id', activeProjectId);
+  }
+  const filter = completedFilter.value;
+  if (filter === 'active') {
+    params.set('completed', 'false');
+  } else if (filter === 'done') {
+    params.set('completed', 'true');
+  }
+  if (dueBeforeInput.value) {
+    params.set('due_before', dueBeforeInput.value);
+  }
+  if (searchInput.value.trim()) {
+    params.set('search', searchInput.value.trim());
+  }
+  tasks = await request(`/api/tasks?${params.toString()}`);
+  renderTasks();
+  updateSummary();
+}
+
+function renderProjects() {
+  projectList.innerHTML = '';
+  projects.forEach((project) => {
+    const item = document.createElement('li');
+    item.className = 'project-item';
+    if (project.id === activeProjectId) {
+      item.classList.add('active');
+    }
+    item.dataset.projectId = project.id;
+
+    const name = document.createElement('span');
+    name.className = 'project-name';
+    const color = document.createElement('span');
+    color.className = 'color-dot';
+    color.style.background = project.color;
+    const label = document.createElement('span');
+    label.textContent = project.name;
+    name.append(color, label);
+    item.appendChild(name);
+
+    item.addEventListener('click', () => {
+      activeProjectId = project.id;
+      setActiveProjectTitle();
+      loadTasks();
+      renderProjects();
+    });
+
+    projectList.appendChild(item);
+  });
+}
+
+function populateProjectSelect() {
+  taskProject.innerHTML = '';
+  const noneOption = document.createElement('option');
+  noneOption.value = '';
+  noneOption.textContent = 'Inbox';
+  taskProject.appendChild(noneOption);
+  projects.forEach((project) => {
+    const option = document.createElement('option');
+    option.value = project.id;
+    option.textContent = project.name;
+    if (project.id === activeProjectId) {
+      option.selected = true;
+    }
+    taskProject.appendChild(option);
+  });
+}
+
+function setActiveProjectTitle() {
+  const project = projects.find((p) => p.id === activeProjectId);
+  activeProjectTitle.textContent = project ? project.name : 'Inbox';
+}
+
+function renderTasks() {
+  taskList.innerHTML = '';
+  const template = document.getElementById('taskTemplate');
+  if (tasks.length === 0) {
+    const emptyState = document.createElement('li');
+    emptyState.className = 'task-item';
+    emptyState.textContent = 'Aucune tâche trouvée. Ajoutez-en une nouvelle !';
+    taskList.appendChild(emptyState);
+    return;
+  }
+
+  tasks.forEach((task) => {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.dataset.taskId = task.id;
+    const checkbox = node.querySelector('.task-checkbox');
+    checkbox.checked = task.completed;
+    const title = node.querySelector('.task-title');
+    title.textContent = task.title;
+    const meta = node.querySelector('.task-meta');
+    const metaItems = [];
+    if (task.due_date) {
+      metaItems.push(`<span class="tag">📅 ${formatDate(task.due_date)}</span>`);
+    }
+    metaItems.push(`<span class="tag">🔥 Priorité ${task.priority}</span>`);
+    if (task.project_id) {
+      const project = projects.find((p) => p.id === task.project_id);
+      if (project) {
+        metaItems.push(`<span class="tag" style="background:${hexToRgba(project.color)};color:${project.color}">📁 ${project.name}</span>`);
+      }
+    }
+    if (task.description) {
+      metaItems.push(`<span>${task.description}</span>`);
+    }
+    meta.innerHTML = metaItems.join('');
+
+    if (task.completed) {
+      node.classList.add('completed');
+    }
+
+    checkbox.addEventListener('change', () => toggleTask(task.id));
+    node.querySelector('.delete-button').addEventListener('click', () => deleteTask(task.id));
+    taskList.appendChild(node);
+  });
+}
+
+function formatDate(value) {
+  const date = new Date(value);
+  return date.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' });
+}
+
+function hexToRgba(hex) {
+  const parsed = hex.replace('#', '');
+  const bigint = parseInt(parsed, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, 0.18)`;
+}
+
+async function createTask(event) {
+  event.preventDefault();
+  const payload = {
+    title: taskTitle.value.trim(),
+    description: taskDescription.value.trim() || null,
+    due_date: taskDue.value || null,
+    priority: Number(taskPriority.value),
+    project_id: taskProject.value ? Number(taskProject.value) : null,
+  };
+  if (!payload.title) {
+    alert('Veuillez indiquer un titre.');
+    return;
+  }
+  await request('/api/tasks', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  taskForm.reset();
+  populateProjectSelect();
+  await loadTasks();
+}
+
+async function toggleTask(taskId) {
+  const updated = await request(`/api/tasks/${taskId}/toggle`, { method: 'PATCH' });
+  tasks = tasks.map((task) => (task.id === taskId ? updated : task));
+  renderTasks();
+  updateSummary();
+}
+
+async function deleteTask(taskId) {
+  if (!confirm('Supprimer cette tâche ?')) {
+    return;
+  }
+  await request(`/api/tasks/${taskId}`, { method: 'DELETE' });
+  tasks = tasks.filter((task) => task.id !== taskId);
+  renderTasks();
+  updateSummary();
+}
+
+function updateSummary() {
+  request('/api/tasks/summary')
+    .then((stats) => {
+      summaryEl.innerHTML = `
+        <span>📌 Total ${stats.total}</span>
+        <span>✅ Terminées ${stats.completed}</span>
+        <span>🚀 Actives ${stats.active}</span>
+      `;
+    })
+    .catch(() => {
+      summaryEl.textContent = 'Impossible de charger le résumé.';
+    });
+}
+
+function handleProjectDialog() {
+  projectDialog.addEventListener('close', async () => {
+    if (projectDialog.returnValue !== 'confirm') {
+      projectNameInput.value = '';
+      return;
+    }
+    try {
+      await request('/api/projects', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: projectNameInput.value.trim(),
+          color: projectColorInput.value,
+        }),
+      });
+      projectNameInput.value = '';
+      await loadProjects();
+      await loadTasks();
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+
+  addProjectBtn.addEventListener('click', () => {
+    projectDialog.showModal();
+    projectNameInput.focus();
+  });
+
+  projectDialogSubmit.addEventListener('click', (event) => {
+    if (!projectNameInput.value.trim()) {
+      event.preventDefault();
+      alert('Veuillez indiquer un nom de projet.');
+    }
+  });
+}
+
+function registerFilters() {
+  completedFilter.addEventListener('change', loadTasks);
+  dueBeforeInput.addEventListener('change', loadTasks);
+  searchInput.addEventListener('input', () => {
+    window.clearTimeout(searchTimeout);
+    searchTimeout = window.setTimeout(loadTasks, 300);
+  });
+}
+
+async function init() {
+  handleProjectDialog();
+  registerFilters();
+  taskForm.addEventListener('submit', createTask);
+  await loadProjects();
+  await loadTasks();
+}
+
+init().catch((error) => {
+  console.error(error);
+  alert('Impossible de charger Taskflow.');
+});

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Taskflow - Gestionnaire de tâches</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700" rel="stylesheet" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="logo">Taskflow</div>
+      <div class="summary" id="summary"></div>
+    </header>
+    <main class="layout">
+      <aside class="sidebar">
+        <div class="section-header">
+          <h2>Projets</h2>
+          <button class="icon-button" id="addProjectBtn" title="Ajouter un projet">+</button>
+        </div>
+        <ul class="project-list" id="projectList"></ul>
+      </aside>
+      <section class="content">
+        <div class="content-header">
+          <div>
+            <h1 id="activeProject">Inbox</h1>
+            <p class="muted" id="projectDescription">Gérez vos tâches quotidiennes.</p>
+          </div>
+          <div class="filters">
+            <select id="completedFilter">
+              <option value="all">Toutes</option>
+              <option value="active">Actives</option>
+              <option value="done">Terminées</option>
+            </select>
+            <input type="date" id="dueBefore" />
+            <input type="text" id="searchInput" placeholder="Rechercher..." />
+          </div>
+        </div>
+        <ul class="task-list" id="taskList"></ul>
+        <form class="task-form" id="taskForm">
+          <h3>Nouvelle tâche</h3>
+          <div class="form-grid">
+            <label>
+              Titre
+              <input type="text" id="taskTitle" required maxlength="120" />
+            </label>
+            <label>
+              Projet
+              <select id="taskProject"></select>
+            </label>
+            <label>
+              Échéance
+              <input type="date" id="taskDue" />
+            </label>
+            <label>
+              Priorité
+              <select id="taskPriority">
+                <option value="4">Urgent</option>
+                <option value="3">Élevée</option>
+                <option value="2" selected>Normale</option>
+                <option value="1">Basse</option>
+              </select>
+            </label>
+          </div>
+          <label>
+            Description
+            <textarea id="taskDescription" rows="3"></textarea>
+          </label>
+          <button type="submit" class="primary">Ajouter la tâche</button>
+        </form>
+      </section>
+    </main>
+
+    <dialog id="projectDialog">
+      <form method="dialog" class="dialog">
+        <h3>Nouveau projet</h3>
+        <label>
+          Nom
+          <input type="text" id="projectName" required maxlength="80" />
+        </label>
+        <label>
+          Couleur
+          <input type="color" id="projectColor" value="#7c3aed" />
+        </label>
+        <menu>
+          <button value="cancel">Annuler</button>
+          <button id="projectDialogSubmit" value="confirm">Créer</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <template id="taskTemplate">
+      <li class="task-item">
+        <div class="task-main">
+          <input type="checkbox" class="task-checkbox" />
+          <div class="task-info">
+            <div class="task-title"></div>
+            <div class="task-meta"></div>
+          </div>
+        </div>
+        <button class="icon-button delete-button" title="Supprimer">×</button>
+      </li>
+    </template>
+
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,375 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f172a;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+  background: linear-gradient(120deg, #1d4ed8, #9333ea);
+  color: #fff;
+  box-shadow: 0 4px 30px rgba(15, 23, 42, 0.3);
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.summary {
+  font-weight: 500;
+  display: flex;
+  gap: 1rem;
+}
+
+.summary span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(4px);
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  max-width: 1200px;
+  margin: 2rem auto;
+  width: 100%;
+  gap: 2rem;
+  padding: 0 2rem 2rem;
+}
+
+.sidebar {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: #0f172a;
+  background: #e2e8f0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.icon-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
+}
+
+.project-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.project-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.project-item:hover,
+.project-item.active {
+  background: rgba(226, 232, 240, 0.1);
+  transform: translateX(4px);
+}
+
+.project-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.content {
+  background: #fff;
+  border-radius: 24px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 30px 40px rgba(15, 23, 42, 0.15);
+}
+
+.content-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.content-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.muted {
+  margin: 0.25rem 0 0;
+  color: #64748b;
+}
+
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.filters select,
+.filters input[type="date"],
+.filters input[type="text"] {
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  background: #f8fafc;
+  min-width: 120px;
+}
+
+.task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.task-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 25px rgba(15, 23, 42, 0.12);
+}
+
+.task-main {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.task-checkbox {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #1d4ed8;
+  cursor: pointer;
+}
+
+.task-checkbox:checked {
+  accent-color: #1d4ed8;
+}
+
+.task-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.task-item.completed .task-title {
+  text-decoration: line-through;
+  color: #94a3b8;
+}
+
+.task-meta {
+  color: #64748b;
+  font-size: 0.85rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.task-form {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1.5rem;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-form h3 {
+  margin: 0;
+}
+
+.task-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.task-form input,
+.task-form select,
+.task-form textarea {
+  border-radius: 12px;
+  border: none;
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+}
+
+.task-form textarea {
+  resize: vertical;
+}
+
+.primary {
+  align-self: flex-end;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+  background: linear-gradient(120deg, #2563eb, #9333ea);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.25);
+}
+
+.delete-button {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+    padding: 0 1.5rem 1.5rem;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .project-list {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+
+  .filters {
+    flex-wrap: wrap;
+  }
+}
+
+.dialog {
+  border: none;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 260px;
+}
+
+.dialog menu {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.dialog button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.5rem 1.2rem;
+  cursor: pointer;
+}
+
+.dialog button[value="confirm"] {
+  background: #2563eb;
+  color: #fff;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.111.0
+sqlmodel==0.0.16
+uvicorn==0.29.0
+jinja2==3.1.3
+python-multipart==0.0.9
+httpx==0.27.0
+pytest==8.2.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,99 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+
+from app.database import get_session
+from app.main import app
+
+
+def get_test_engine():
+    return create_engine("sqlite://", connect_args={"check_same_thread": False})
+
+
+def create_db(engine):
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def create_client():
+    engine = get_test_engine()
+    create_db(engine)
+    app.dependency_overrides[get_session] = override_get_session(engine)
+    client = TestClient(app)
+    return client, engine
+
+
+def test_project_lifecycle():
+    client, engine = create_client()
+    try:
+        response = client.get("/api/projects")
+        assert response.status_code == 200
+        projects = response.json()
+        assert any(project["name"] == "Inbox" for project in projects)
+
+        payload = {"name": "Travail", "color": "#16a34a"}
+        response = client.post("/api/projects", json=payload)
+        assert response.status_code == 201
+        project = response.json()
+        assert project["name"] == "Travail"
+
+        update = {"name": "Travail Pro"}
+        response = client.put(f"/api/projects/{project['id']}", json=update)
+        assert response.status_code == 200
+        assert response.json()["name"] == "Travail Pro"
+
+        response = client.delete(f"/api/projects/{project['id']}")
+        assert response.status_code == 204
+    finally:
+        app.dependency_overrides.clear()
+        engine.dispose()
+
+
+def test_task_workflow():
+    client, engine = create_client()
+    try:
+        project_payload = {"name": "Personnel", "color": "#f97316"}
+        project = client.post("/api/projects", json=project_payload).json()
+
+        task_payload = {
+            "title": "Acheter des fleurs",
+            "description": "Penser au bouquet d'anniversaire",
+            "priority": 3,
+            "project_id": project["id"],
+            "due_date": date.today().isoformat(),
+        }
+        response = client.post("/api/tasks", json=task_payload)
+        assert response.status_code == 201
+        task = response.json()
+        assert task["title"] == "Acheter des fleurs"
+        assert task["completed"] is False
+
+        response = client.patch(f"/api/tasks/{task['id']}/toggle")
+        assert response.status_code == 200
+        toggled = response.json()
+        assert toggled["completed"] is True
+
+        update_payload = {"priority": 4, "description": "Bouquet avec des pivoines"}
+        response = client.put(f"/api/tasks/{task['id']}", json=update_payload)
+        assert response.status_code == 200
+        updated = response.json()
+        assert updated["priority"] == 4
+        assert "pivoines" in updated["description"]
+
+        summary = client.get("/api/tasks/summary").json()
+        assert summary["total"] >= 1
+        assert summary["completed"] >= 1
+
+        response = client.delete(f"/api/tasks/{task['id']}")
+        assert response.status_code == 204
+    finally:
+        app.dependency_overrides.clear()
+        engine.dispose()


### PR DESCRIPTION
## Summary
- build FastAPI backend with SQLite persistence for projects and tasks
- add interactive single-page UI for managing projects, filters, and tasks
- cover main workflows with pytest-based API tests and document setup in README

## Testing
- pytest *(fails: fastapi dependency unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deeef32b1c83299ce6363a00e5557c